### PR TITLE
fix(parse): tag

### DIFF
--- a/src/parse-github-event.ts
+++ b/src/parse-github-event.ts
@@ -99,9 +99,9 @@ export function parse(event: Event): ParsedEvent | undefined {
                 case 'tag':
                     return {
                         login,
-                        text: "created tag {{ref_type}} at {{repository}}",
+                        text: "created tag {{ref}} at {{repository}}",
                         data: {
-                            ref_type: event.payload.ref_type,
+                            ref: event.payload.ref,
                             repository: repo
                         },
                         html_url: GITHUB_DOMAIN + "/" + repo + "/releases/tag/" + event.payload.ref

--- a/src/parse-github-event.ts
+++ b/src/parse-github-event.ts
@@ -310,6 +310,17 @@ export function parse(event: Event): ParsedEvent | undefined {
                         },
                         html_url: GITHUB_DOMAIN + "/" + repo
                     };
+                case 'tag':
+                    return {
+                        login,
+                        text: "deleted tag {{ref}} at {{repository}}",
+                        data: {
+                            ref: event.payload.ref,
+                            ref_type: event.payload.ref_type,
+                            repository: repo
+                        },
+                        html_url: GITHUB_DOMAIN + "/" + repo
+                    };
             }
             break;
         case 'PublicEvent':


### PR DESCRIPTION
Thanks for the project!

I used it in my app [buddy-github-events](https://github.com/lawvs/buddy-github-events) and found some bugs.

- DeleteEvent tag type is not parsed
- CreateEvent tag type parse error

This is example event payload
```json
[
  {
    "id": "9392345111",
    "type": "DeleteEvent",
    "actor": {
      "id": 133413,
      "login": "GITHUB_USERNAME",
      "display_login": "GITHUB_USERNAME",
      "gravatar_id": "",
      "url": "https://api.github.com/users/GITHUB_USERNAME",
      "avatar_url": "https://avatars.githubusercontent.com/u/11111?"
    },
    "repo": {
      "id": 146097694,
      "name": "GITHUB_USERNAME/PROJECT_NAME_1",
      "url": "https://api.github.com/repos/GITHUB_USERNAME/PROJECT_NAME_1"
    },
    "payload": {
      "ref": "v1.0.0",
      "ref_type": "tag", <--
      "pusher_type": "user"
    },
    "public": true,
    "created_at": "2019-04-01T23:27:00Z"
  },
  {
    "id": "93705015111",
    "type": "CreateEvent",
    "actor": {
      "id": 3213111,
      "login": "GITHUB_USERNAME",
      "display_login": "GITHUB_USERNAME",
      "gravatar_id": "",
      "url": "https://api.github.com/users/GITHUB_USERNAME",
      "avatar_url": "https://avatars.githubusercontent.com/u/1111111?"
    },
    "repo": {
      "id": 17011111,
      "name": "ORG_NAME/PROJECT_NAME",
      "url": "https://api.github.com/repos/ORG_NAME/PROJECT_NAME"
    },
    "payload": {
      "ref": "v1.1.1",  <-- tag name
      "ref_type": "tag",
      "master_branch": "master",
      "description": "PROJECT DESC",
      "pusher_type": "user"
    },
    "public": true,
    "created_at": "2019-04-01T11:11:00Z",
    "org": {
      "id": 11751111,
      "login": "ORG_NAME",
      "gravatar_id": "",
      "url": "https://api.github.com/orgs/ORG_NAME",
      "avatar_url": "https://avatars.githubusercontent.com/u/1111111?"
    }
  }
]
```

Reference https://developer.github.com/v3/activity/events/types/#deleteevent
