### PR TITLE
fix: types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-declare namespace GithubApi {
+export declare namespace GithubApi {
   /**
    * EventType
    * @see https://developer.github.com/v3/activity/events/types/


### PR DESCRIPTION
何だか`types.d.ts`パッケージングされていません

```
ERROR in [at-loader] ./node_modules/parse-github-event/lib/parse-github-event.d.ts:1:40
    TS2307: Cannot find module './types'.
```

```
> tree lib

lib
├── parse-github-event.d.ts
├── parse-github-event.js
└── parse-github-event.js.map
```
parse-github-event.d.ts
```js
import { GithubApi, ParsedEvent } from "./types"; // <- ERROR
export declare function parse(event: GithubApi.GithubEvent): ParsedEvent | undefined;
export declare function compile(parsedEvent: ParsedEvent): string;
```